### PR TITLE
Fix quoting in the request function

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,8 +1,10 @@
 import hashlib, hmac, os
 import urllib.request as r
 import urllib.error
+import urllib.parse
 
 def request(url, data=None, method="GET", headers={}):
+    url = urllib.parse.quote(url, safe='/:?=&')
     robj = r.Request(url, data, method=method, headers=headers)
     try:
         d = r.urlopen(robj).read()

--- a/nodyno.py
+++ b/nodyno.py
@@ -1,6 +1,7 @@
 import os.path, subprocess, glob, time, signal, sys, threading, multiprocessing
 import urllib.request as r
 import urllib.error, hashlib, hmac, base64, getpass, functools, random
+import urllib.parse
 
 def restartafterdelay(t, file=__file__):
     subprocess.run("python -c \"import time, subprocess; file2 = "+ascii(file)+"; time.sleep("+str(t)+"); subprocess.run(f\\\"python \\\\\\\"{file2}\\\\\\\"\\\")\" & pause")
@@ -47,7 +48,7 @@ def a():
 
 def request(url, data=None, method="GET", headers={}):
     # quote
-    url = urllib.parse.quote(url)
+    url = urllib.parse.quote(url, safe='/:?=&')
     robj = r.Request(url, data, method=method, headers=headers)
     try:
         d = r.urlopen(robj).read()


### PR DESCRIPTION
Update the `request` function to properly quote URLs in `install.py` and `nodyno.py`.

* **install.py**
  - Import `urllib.parse` at the top of the file.
  - Quote the `url` parameter using `urllib.parse.quote` with appropriate safe characters in the `request` function.

* **nodyno.py**
  - Import `urllib.parse` at the top of the file.
  - Quote the `url` parameter using `urllib.parse.quote` with appropriate safe characters in the `request` function.

